### PR TITLE
Fix :znap:compinit

### DIFF
--- a/znap.zsh
+++ b/znap.zsh
@@ -58,7 +58,7 @@
     add-zsh-hook -d precmd :znap:compinit
     unfunction :znap:compinit
 
-    if [[ ! -v _comp_dumpfile ]]; then
+    if [[ ! -v _comp_setup || ! -f $_comp_dumpfile ]]; then
       autoload -Uz compinit
       compinit -C -d $_comp_dumpfile
     fi


### PR DESCRIPTION
`compinit` will not  be executed because `_comp_dumpfile` is already defined.

Changed to run compinit when compinit is not running or zcompdump does not exist.