### PR TITLE
removed irrevelant question in znap rm

### DIFF
--- a/functions/.znap.rm
+++ b/functions/.znap.rm
@@ -30,7 +30,7 @@ zmodload -Fa zsh/parameter p:commands
         'tell application "Finder" to delete every item of {'${(j:, :)items}'}' >/dev/null
     else
       print zf_rm $(eval "ls -d $files[@]:t")
-      zf_rm -irs $files[@]
+      zf_rm -irsf $files[@]
     fi
   } always {
     [[ -x $pwd ]] &&


### PR DESCRIPTION
I was deleting pure and it asked this
`zf_rm: remove '/data/data/com.termux/files/home/.znap/pure'?`
for almost every file and directory
so this will make it not ask this.