### PR TITLE
Fix: zsh: no directory expansion: ~[$plugin] when initially source the plugin.

### DIFF
--- a/functions/.znap.source
+++ b/functions/.znap.source
@@ -15,7 +15,7 @@ local -i ret=0
 
   local plugin=$1
   if [[ $plugin == */* ]]; then
-    plugin=${${plugin##*/}%.git}
+    plugin=${${plugin}%.git}
     [[ -d ~[$plugin] ]] ||
       .znap.clone $1
   fi


### PR DESCRIPTION
Directory expansion failed won't return false value and run `.znap.clone $1` ,instead it will result in an error `zsh: no directory expansion: ~[$plugin]` and terminate the script.
https://github.com/marlonrichert/zsh-snap/blob/45ddfd7dfe81679aca2405ce578e29133bc48968/functions/.znap.source#L19-L20

It failed because  `plugin=${${plugin##*/}%.git} ` truncated the first part, and the directory didn't actually exist.
https://github.com/marlonrichert/zsh-snap/blob/45ddfd7dfe81679aca2405ce578e29133bc48968/functions/.znap.source#L18-L20
https://github.com/marlonrichert/zsh-snap/blob/45ddfd7dfe81679aca2405ce578e29133bc48968/functions/..znap.dirname#L8-L17

This pr just removed the truncation since it was already done in https://github.com/marlonrichert/zsh-snap/blob/45ddfd7dfe81679aca2405ce578e29133bc48968/functions/..znap.dirname#L9