### PR TITLE
Fix readme typo: disabling auto git maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ commands will run faster.
 
 To selectively disable this feature, add
 ```zsh
-zstyle 'znap:*:<glob pattern>' git-maintenance off
+zstyle ':znap:<glob pattern>' git-maintenance off
 ```
 to your `.zshrc` file. Next time you run `znap pull`, `git maintenance` will then be disabled for
 each repo whose name matches `<glob pattern>`. Use `*` as your [glob


### PR DESCRIPTION
Couldn't get this working based on the example in the readme, this seemed to fix it. :jack_o_lantern: 