### PR TITLE
Fix `git maintenance` invocation

### DIFF
--- a/functions/.znap.pull
+++ b/functions/.znap.pull
@@ -31,7 +31,7 @@ autoload +X -Uz is-at-least
       if zstyle -T :znap:pull:${r:t} git-maintenance; then
         git -C $r maintenance start &> /dev/null
       else
-        git -C $r maintenance unregister --quiet
+        git -C $r maintenance unregister &> /dev/null
       fi
     done
   fi

--- a/functions/.znap.uninstall
+++ b/functions/.znap.uninstall
@@ -18,7 +18,7 @@ private repo=
 for repo in ~znap/$^@:t; do
   if [[ -d $repo ]]; then
     is-at-least 2.31 ${${=$( git --version )}[3]} &&
-        git -C $repo maintenance unregister --quiet
+        git -C $repo maintenance unregister &> /dev/null
     print 'Removing:'
     file=( ~/.local/bin/* ${XDG_DATA_HOME:-~/.local/share}/zsh/site-functions/* )
     while (( $#file ));do


### PR DESCRIPTION
Before submitting your PR (pull request), please
check the following:
* [x] There is no other PR (open or closed)
  similar to yours. If there is, please first
  discuss over there.
* [x] Each commit messages follows the [Seven
  Rules of a Great Commit
  Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes
  `Fixes #<bug>` or `Resolves #<issue>` in its 
  body (not subject) for each issue it resolves
  (if any).
* [x] You have
  [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
  any redundant or insignificant commits.

Currently, `znap uninstall` fails, along with disabling `git maintenance` with `znap pull` because of this bug.

Related: #140