### PR TITLE
Fix non-interactive compilation

### DIFF
--- a/functions/.znap.compile
+++ b/functions/.znap.compile
@@ -49,8 +49,10 @@ while (( $#files[@] )); do
         opt=R
       fi
 
-      if [[ $funcstack[2] == znap ]] && emulate zsh -c "zcompile -U$opt -- ${(q)f}"; then
-        print -Pr -- "${(D)f:h}/%F{green}$f:t.zwc%f"
+      if emulate zsh -c "zcompile -U$opt -- ${(q)f}"; then
+        if [[ $funcstack[2] == znap ]] ; then
+          print -Pr -- "${(D)f:h}/%F{green}$f:t.zwc%f"
+        fi
       else
         ret=1
         zf_rm -f -- $f.zwc


### PR DESCRIPTION
`.znap.compile` checks the `funcstack`, with the intent of determining whether or not to output user visible messages -- they should only be output when called directly from the `znap` CLI tool.

Unfortunately, this check was written in a way that means that when called from outside of the main `znap` function (eg, compdump background compilation, auto-compile), no compilation happened.

This change re-orders the checks so that `.znap.compile` works when called from other parts of znap, like compdump compilation.

Fixes #267

Before submitting your PR (pull request), please
check the following:
* [x] There is no other PR (open or closed)
  similar to yours. If there is, please first
  discuss over there.
* [x] Each commit messages follows the [Seven
  Rules of a Great Commit
  Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes
  `Fixes #<bug>` or `Resolves #<issue>` in its 
  body (not subject) for each issue it resolves
  (if any).
* [x] You have
  [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
  any redundant or insignificant commits.
