### PR TITLE
Check .git dir in clone migration check

### DIFF
--- a/functions/.znap.clone.task
+++ b/functions/.znap.clone.task
@@ -15,7 +15,7 @@ local gitdir=''
 local -P name=${url#*@*:}
 private new= old=$gitdir/${name:t:r}
 
-if [[ -d $old ]]; then
+if [[ -d ${old}/.git ]]; then
   if new=$gitdir/${${(M)$(
       git -C $old remote get-url origin 2> /dev/null
   )%%[^/:]##/[^/:]##}%.git}; then


### PR DESCRIPTION
When the last part of the repository name is the same as the first part of it, the old -> new directory migration code is triggered, since a "top level" directory of the second part's name exists.

In the least-bad case, where the `repos-dir` is separate from the znap or any other git repository, this triggers an unnecessary invocation of git, costing a few ms of startup time.

However, the bad case is that some users seem to have set things up so that their `repos-dir` is a subdirectory of the znap repository. This causes the `git remote ...` call to succeed, triggering the full migration, and cloning the repository back into the same place.

Instead of just checking for a directory's existence, we can check for a git repository's existence fairly cheaply by checking for the `git` directory.

Fixes #257

Before submitting your PR (pull request), please
check the following:
* [x] There is no other PR (open or closed)
  similar to yours. If there is, please first
  discuss over there.
* [x] Each commit messages follows the [Seven
  Rules of a Great Commit
  Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes
  `Fixes #<bug>` or `Resolves #<issue>` in its 
  body (not subject) for each issue it resolves
  (if any).
* [x] You have
  [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
  any redundant or insignificant commits.
