### PR TITLE
Use builtin cd for znap status

### DIFF
--- a/functions/.znap.status
+++ b/functions/.znap.status
@@ -23,7 +23,7 @@ autoload +X -Uz is-at-least
   emulate -L zsh; setopt $_znap_opts
 
   print -nr -- "${$( eval "ls -d $1" )%[/@]} "
-  cd -q $1
+  builtin cd -q $1
 
   local -a upstream=()
   private err="$( ..znap.fetch )"


### PR DESCRIPTION
znap uses the `cd` command inside `znap status`, which can cause problems with setups on which the `cd` command has been overridden - for example, with [zoxide](https://github.com/ajeetdsouza/zoxide).

Using `builtin cd` will ensure that `znap` uses the correct `cd` command.

Fixes https://github.com/ajeetdsouza/zoxide/issues/729