### PR TITLE
fix: use builtin cd for pull and eval commands

### DIFF
--- a/functions/.znap.eval
+++ b/functions/.znap.eval
@@ -39,7 +39,7 @@ private _P__line= _P__header="#${(q+)_P__cmd}" _P__index=$_P__repo/.git/index
   if [[ $_P__line != $_P__header ]] ||
       [[ -n $_P__repo && -f $_P__index && $_P__index -nt $_P__cache_file ]]; then
     [[ -d $_P__repo ]] &&
-        cd -q -- $_P__repo
+        builtin cd -q -- $_P__repo
     print -r -- "$_P__header" >! $_P__cache_file
     eval "$_P__cmd" >>! $_P__cache_file
     .znap.compile $_P__cache_file

--- a/functions/.znap.pull
+++ b/functions/.znap.pull
@@ -17,7 +17,7 @@ autoload +X -Uz is-at-least
   done
 
   (
-    cd -q $gitdir
+    builtin cd -q $gitdir
 
     local -a repos=()
     ..znap.repos pull "$@"
@@ -46,7 +46,7 @@ autoload +X -Uz is-at-least
   emulate -L zsh; setopt $_znap_opts
 
   print -nr -- "${$( eval "ls -d $1" )%[/@]} "
-  cd -q $1
+  builtin cd -q $1
 
   local -a upstream=()
   if ! ..znap.fetch; then


### PR DESCRIPTION
Similar to: https://github.com/marlonrichert/zsh-snap/pull/277 but I've applied the same fix for the pull and eval commands.

Fixes https://github.com/ajeetdsouza/zoxide/issues/729