### PR TITLE
Allow git repos to be submodules

### DIFF
--- a/functions/..znap.dirname
+++ b/functions/..znap.dirname
@@ -10,10 +10,10 @@
 
   case $1 in
     ( ${1:t} )
-      dirs=( $gitdir/{*/,}$1/.git(Non-/:h) )
+      dirs=( $gitdir/{*/,}$1/.git(Non-:h) )
     ;;
     ( ${1:t2} )
-      dirs=( $gitdir/$1/.git(Non-/:h) )
+      dirs=( $gitdir/$1/.git(Non-:h) )
     ;;
   esac
 
@@ -36,17 +36,17 @@
   private subdirs=${1#$gitdir}
   private repo=$gitdir
   private next=
-  while [[ ! -d $repo/.git && -n $subdirs ]]; do
+  while [[ ! -e $repo/.git && -n $subdirs ]]; do
     next=${subdirs:h2}
     repo+=$next
     subdirs=${subdirs#$next}
   done
   private name=${repo#$gitdir}
 
-  [[ -d $gitdir/$name/.git ]] ||
+  [[ -e $gitdir/$name/.git ]] ||
       return 1
 
-  private -a samenamed=( $gitdir/{,*/}${name:t}/.git(N-/) )
+  private -a samenamed=( $gitdir/{,*/}${name:t}/.git(N-) )
   (( $#samenamed[@] == 1 )) &&
     name=${name:t}
   reply=( "$name" $#repo )

--- a/functions/..znap.repos
+++ b/functions/..znap.repos
@@ -7,7 +7,7 @@ if (( $# > 1 )); then
   repos=( $gitdir/${^@}(ND-/) )
 
 else
-  repos=( $gitdir/*{,/*}/.git(ND-/:h) )
+  repos=( $gitdir/*{,/*}/.git(ND-:h) )
 
   local -a exclude=()
   if zstyle -a ":znap:$1:" exclude exclude; then


### PR DESCRIPTION
I'm using yadm and would like to track the plugins as submodules of the yadm repository. When checking out such a submodule, .git is not a directory, but rather a file. This resulted in the following error, for each of the plugins that I track as a submodule:

```
% exec zsh
.znap.source:16: no directory expansion: ~[superbrothers/zsh-kubectl-prompt] 
.znap.source:16: no directory expansion: ~[mattmc3/zfunctions] 
.znap.source:16: no directory expansion: ~[olets/zsh-abbr] 
.znap.source:16: no directory expansion: ~[Aloxaf/fzf-tab]
```
With this commit ..znap.repos and ..znap.dirname handle that case. Please note that there are other checks in some of the scripts that do also check for a .git directory. They may still need to be changed.

Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [ ] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the
  first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.
