### PR TITLE
Fix compile command conditionals

### DIFF
--- a/functions/..znap.auto-compile
+++ b/functions/..znap.auto-compile
@@ -8,6 +8,6 @@ zstyle -s :znap: auto-compile-ignore exclude \| &&
 include=( "${${(@vu)functions_source}[@]:#$~exclude}" )
 
 (( $#include )) &&
-    ( .znap.compile &> /dev/null ) &|
+    ( .znap.compile $include &> /dev/null ) &|
 
 true

--- a/functions/.znap.compile
+++ b/functions/.znap.compile
@@ -18,7 +18,8 @@ fi
 files=( ${(@n)files} )
 
 private -i ret=0
-private f= func= opt=
+private f= opt=
+private -a funcs=()
 while (( $#files[@] )); do
   {
     f=$files[1]
@@ -42,15 +43,18 @@ while (( $#files[@] )); do
     fi
 
     if ! [[ -e $f.zwc ]]; then
-      func=${(k)functions_source[(r)$f:a]}
-      if [[ -n $func && $func == $f:t ]] || (( fpath[(i)$f:a:h] )); then
+      # (R) collects all (not just the first) functions autoloaded from $f;
+      # (e) matches $f:a literally, since it may contain glob-special chars;
+      # (I) returns 0 (not $#array+1) when there's no match.
+      funcs=( ${(@k)functions_source[(Re)$f:a]} )
+      if (( funcs[(Ie)$f:t] )) || (( fpath[(Ie)$f:a:h] )); then
         opt=zM
       else
         opt=R
       fi
 
       if emulate zsh -c "zcompile -U$opt -- ${(q)f}"; then
-        if [[ $funcstack[2] == znap ]] ; then
+        if [[ ${funcstack[2]:-} == znap ]] ; then
           print -Pr -- "${(D)f:h}/%F{green}$f:t.zwc%f"
         fi
       else


### PR DESCRIPTION
* `(( fpath[(i)$f:a:h] ))` always evaluates to true. Fix this conditional to use the `I` subscript flag instead of `i`
* Add the `e` subscript flag to avoid the file paths being interpreted as patterns
* The `${(k)functions_source[(r)$f:a]} == $f:t` conditional only checks if the first function found. Since an autoloaded zsh script can define multiple functions, this fixes the conditional to check all functions defined by that source file.
  * This check might be entirely unnecessary because any autoloaded functions should be in `$fpath`. And the `fpath` conditional is more semantically consistent in any case

---

Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [ ] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the
  first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.
